### PR TITLE
Add check command to readd movies when not on streaming services anymore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.10b0
     hooks:
       - id: black
         name: Python Black

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ $ excludarr exclude -a not-monitored
 Are you sure you want to change the status of the movies to: not-monitored? (y/N) y
 ```
 
+To check the "not-monitored" movies are not on a configured streaming provider anymore and add them back to monitored state:
+
+```
+$ excludarr check
+      ╷
+  ID  │ Title
+ ═════╪════════════════════════════════════════════
+  33  │ Iron Man
+  35  │ Candyman
+  36  │ Avatar
+  37  │ The Avengers
+  39  │ Skyfall
+  41  │ Iron Man 3
+      ╵
+Are you sure you want to change the status of the movies back to monitored? (y/N) y
+Succesfully changed the movies in Radarr to Monitored
+```
+
 Use the `--help` flag to get more information.
 
 ### Docker
@@ -78,7 +96,7 @@ RADARR_URL | http://localhost:7878 | The Radarr URL
 RADARR_API_KEY | secret | Your Radarr API Key
 RADARR_VERIFY_SSL | false | To enable SSL verify, can be `true` or `false`
 
-You can put those variables in a env file (e.g. name is=t `excludarr.env`) and use it in a command (recommended way). Look the `docker_example.env` for an example. If you have set your variables properly, you can execute excludarr in docker by just adding the command and paramaters at the end of the docker command. Example:
+You can put those variables in a env file (e.g. `excludarr.env`) and use it in a command (recommended way). Look the `docker_example.env` for an example. If you have set your variables properly, you can execute excludarr in docker by just adding the command and paramaters at the end of the docker command. Example:
 
 ```bash
 docker run -it --rm --env-file excludarr.env haijeploeg/excludarr:latest exclude -a delete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 ---
-version: "2.1"
+
+version: "3"
 services:
   radarr:
     image: linuxserver/radarr
@@ -10,4 +11,15 @@ services:
       - TZ=Europe/Amsterdam
     ports:
       - 7878:7878
+    restart: unless-stopped
+
+  sonarr:
+    image: linuxserver/sonarr
+    container_name: sonarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Amsterdam
+    ports:
+      - 8989:8989
     restart: unless-stopped

--- a/excludarr/controllers/base.py
+++ b/excludarr/controllers/base.py
@@ -6,6 +6,7 @@ from ..core.version import get_version
 from ..core.pyradarr import Radarr
 from ..core.pytmdb import TMDB, TMDBException
 
+from rich import box
 from rich.live import Live
 from rich.table import Table
 
@@ -46,7 +47,6 @@ class Base(Controller):
         tmdb_api_key,
         exclude_providers,
         country,
-        media_type,
         action,
         force,
         remove_if_not_found,
@@ -67,12 +67,13 @@ class Base(Controller):
         exclude_ids = {}
 
         # Setup the rich table
-        table = Table()
-        table.add_column("ID")
-        table.add_column("Title")
-        table.add_column("Providers")
+        table = Table(box=box.MINIMAL_DOUBLE_HEAD)
 
         with Live(table):
+            # Setup columns
+            table.add_column("ID")
+            table.add_column("Title")
+            table.add_column("Providers")
             # Get all movies from radarr and check if tmdbid is being streamed on configured providers
             for movie in radarr.movie.get_all_movies():
                 try:
@@ -86,7 +87,7 @@ class Base(Controller):
                         x["provider_name"].lower() for x in tmdb_providers["flatrate"]
                     ]
 
-                    # Check if the founded providers are in
+                    # Check if the founded providers are in the configured list of configured providers
                     providers = [x for x in local_providers if x in exclude_providers]
                     if providers:
                         exclude_ids.update({movie["id"]: movie})
@@ -154,6 +155,85 @@ class Base(Controller):
             self.app.print("Succesfully changed the movies in Radarr to Not Monitored")
             if delete_files:
                 self.app.print("Succesfully deleted any files if there where any")
+
+    def _check_radarr(
+        self,
+        tmdb_api_key,
+        exclude_providers,
+        country,
+        yes
+    ):
+        # Get radarr variables
+        radarr_url = self.app.config.get("radarr", "url")
+        radarr_api_key = self.app.config.get("radarr", "api_key")
+        radarr_verify_ssl = self.app.config.get("radarr", "verify_ssl")
+
+        # Setup Radarr and TMDB
+        radarr = Radarr(radarr_url, radarr_api_key, ssl_verify=radarr_verify_ssl)
+        tmdb = TMDB(tmdb_api_key)
+
+        # Setup a list of ids to delete
+        exclude_ids = {}
+
+        # Setup the rich table
+        table = Table(box=box.MINIMAL_DOUBLE_HEAD)
+
+        with Live(table):
+            # Setup columns
+            table.add_column("ID")
+            table.add_column("Title")
+            # Get all movies from radarr and check if tmdbid is being streamed on configured providers
+            for movie in radarr.movie.get_all_movies():
+                try:
+                    if not movie["monitored"]:
+                        # Get the providers in the specified country of the movie from TMDB
+                        tmdb_providers = tmdb.movie.get_watch_providers(movie["tmdbId"])[
+                            "results"
+                        ][country]
+
+                        # Add all found providers to a list
+                        local_providers = [
+                            x["provider_name"].lower() for x in tmdb_providers["flatrate"]
+                        ]
+
+                        # Check if the founded providers are in the configured list of configured providers
+                        providers = [x for x in local_providers if x in exclude_providers]
+
+                        if not providers:
+                            exclude_ids.update({movie["id"]: movie})
+                            table.add_row(
+                                f"{movie['id']}",
+                                f"{movie['title']}",
+                            )
+                except TMDBException:
+                    pass
+                except KeyError:
+                    # This will only raise if there is no streaming provider found
+                    # using the selected country. 
+                    exclude_ids.update({movie["id"]: movie})
+                    table.add_row(
+                        f"{movie['id']}",
+                        f"{movie['title']}",
+                    )
+
+        # Set execute_action to false
+        execute_action = False
+
+        # Prompt when force is not set
+        if not yes:
+            p = shell.Prompt(
+                f"Are you sure you want to change the status of the movies back to monitored? (y/N)",
+                default="N",
+            )
+            res = p.prompt()
+
+            if res.upper() == "Y":
+                execute_action = True
+        else:
+            execute_action = True
+
+        if execute_action and exclude_ids:
+            pass
 
     @ex(
         label="exclude",
@@ -262,11 +342,78 @@ class Base(Controller):
                 tmdb_api_key,
                 exclude_providers,
                 country,
-                media_type,
                 action,
                 force,
                 remove_if_not_found,
                 delete_files,
                 add_import_exclusion,
                 legacy_exclude,
+            )
+
+    @ex(
+        label="check",
+        help="Checks if there are any movies that should change from not-monitored to monitored.",
+        arguments=[
+            (
+                ["-p", "--providers"],
+                {
+                    "help": "a single streaming provider, can be set multiple times",
+                    "action": "append",
+                    "default": [],
+                    "dest": "providers",
+                },
+            ),
+            (
+                ["-c", "--country"],
+                {
+                    "help": "the 2 letter country code you are living in",
+                    "action": "store",
+                },
+            ),
+            (
+                ["-t", "--type"],
+                {
+                    "help": "the type of endpoint to reach. Only Radarr is supported at the moment.",
+                    "action": "store",
+                    "default": "radarr",
+                    "choices": ["radarr"],
+                },
+            ),
+            (
+                ["-y", "--yes"],
+                {"help": "auto accept the status change question", "action": "store_true"},
+            ),
+        ],
+    )
+    def check(self):
+        # Get command line arguments
+        exclude_providers = self.app.pargs.providers
+        country = self.app.pargs.country
+        media_type = self.app.pargs.type
+        yes = self.app.pargs.yes
+
+        # Get TMDB configuration
+        tmdb_api_key = self.app.config.get("tmdb", "api_key")
+
+        # Set defaults if there are none provided
+        if len(exclude_providers) == 0:
+            exclude_providers = self.app.config.get("general", "providers")
+        if country == None:
+            country = self.app.config.get("general", "country")
+
+        # Ensure the 2 letter country code is uppercase
+        country = country.upper()
+
+        # Ensure the providers list is all lowercase
+        exclude_providers = [x.lower() for x in exclude_providers]
+
+        # Check wether to list sonarr or radarr
+        if media_type == "sonarr":
+            pass
+        elif media_type == "radarr":
+            self._check_radarr(
+                tmdb_api_key,
+                exclude_providers,
+                country,
+                yes
             )


### PR DESCRIPTION
This PR fixes #15 . Add excludarr check to re-add movies that have been set to not-monitored by the exclude command. This check command will check if the not-monitored movies are still listed on a streaming provider. If the movie is not on a streaming provider, it will change the status back to monitored.