### PR TITLE
fix[readme]: Fix typo in README

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+---
+
+name: lint
+
+'on':
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run hadolint
+        uses: brpaz/hadolint-action@v1.3.1
+        with:
+          dockerfile: Dockerfile
+
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint Markdown
+        uses: actionshub/markdownlint@main

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Excludarr
 By default there is no option to exclude streaming providers from the automatically imported movies throught lists in Radarr. I have created 2 basic API wrappers to connect to Radarr and TMDB (the available API wrappers did not work). This script will do the following:
 1. Get a full overview of movies.
-2. Exctract the tmdbid value of each movie found.
+2. Extract the tmdbid value of each movie found.
 3. Lookup the extracted `tmdbid` value from Radarr at TMDB itself and check if the movie is available on one of the chosen providers in your country.
 4. All movie ids (database ids from Radarr) that are available on one of the chosen streaming services will be deleted and excluded from auto import in the future.
 


### PR DESCRIPTION
- Add linting of markdown and dockerfile while we're on it :-)

Signed-off-by: Jeffrey Bouter <jb@warpnet.nl>