### PR TITLE
Fix UI bug when deleting series

### DIFF
--- a/excludarr/commands/sonarr.py
+++ b/excludarr/commands/sonarr.py
@@ -82,8 +82,28 @@ def exclude(
                 season for season in values["seasons"] if season["monitored"] or season["has_file"]
             ]
         else:
-            values["episodes"] = [episode for episode in values["episodes"] if episode.get("monitored", False)]
-            values["seasons"] = [season for season in values["seasons"] if season.get("monitored", False)]
+            values["episodes"] = [
+                episode for episode in values["episodes"] if episode.get("monitored", False)
+            ]
+            values["seasons"] = [
+                season for season in values["seasons"] if season.get("monitored", False)
+            ]
+
+        # Determine if serie should be deleted fully
+        sonarr_total_monitored_seasons = len(
+            [season for season in values["sonarr_object"]["seasons"] if season["monitored"]]
+        )
+        total_seasons = len([season["season"] for season in values["seasons"]])
+
+        if (
+            total_seasons == sonarr_total_monitored_seasons
+            and values["ended"]
+            and action == Action.delete
+        ):
+            values["full_delete"] = True
+        else:
+            values["full_delete"] = False
+
     if action == Action.not_monitored:
         series_to_exclude = {
             id: values
@@ -95,7 +115,8 @@ def exclude(
         series_to_exclude = {
             id: values
             for id, values in series_to_exclude.items()
-            if (values["episodes"] or values["seasons"] or values["ended"])
+            if (values["episodes"] or values["seasons"])
+            or values["full_delete"]
             and values["title"] not in config.sonarr_excludes
         }
 

--- a/excludarr/commands/sonarr.py
+++ b/excludarr/commands/sonarr.py
@@ -143,13 +143,9 @@ def exclude(
         if confirmation:
             for sonarr_id, data in series_to_exclude.items():
                 sonarr_object = data["sonarr_object"]
-                sonarr_ended = data["ended"]
                 sonarr_total_seasons = sonarr_object["statistics"]["seasonCount"]
-                sonarr_total_monitored_seasons = len(
-                    [season for season in sonarr_object["seasons"] if season["monitored"]]
-                )
+                sonarr_full_delete = data["full_delete"]
                 seasons = [season["season"] for season in data["seasons"]]
-                total_seasons = len(seasons)
                 episodes = data["episodes"]
                 episode_ids = [
                     episode["episode_id"]
@@ -160,7 +156,7 @@ def exclude(
 
                 # Check if total seasons match with the amount of seasons to exclude and delete or
                 # change the status to not monitored for the whole serie
-                if sonarr_total_monitored_seasons == total_seasons and sonarr_ended:
+                if sonarr_full_delete:
                     if action == Action.delete:
                         sonarr.delete_serie(sonarr_id, delete_files, exclusion)
                     elif action == Action.not_monitored:

--- a/excludarr/utils/output.py
+++ b/excludarr/utils/output.py
@@ -69,6 +69,7 @@ def print_series_to_exclude(series, total_filesize):
         table.add_column("Episodes")
         table.add_column("Providers")
         table.add_column("Ended")
+        table.add_column("Full delete")
 
         for _, serie in series.items():
             release_year = str(serie["release_year"])
@@ -78,9 +79,12 @@ def print_series_to_exclude(series, total_filesize):
             episodes = filters.get_pretty_episodes(serie["episodes"])
             providers = serie["providers"]
             ended = filters.bool2str(serie["ended"])
+            full_delete = filters.bool2str(serie["full_delete"])
 
             # Add table rows
-            table.add_row(release_year, title, diskspace, season, episodes, providers, ended)
+            table.add_row(
+                release_year, title, diskspace, season, episodes, providers, ended, full_delete
+            )
 
 
 def print_series_to_re_add(series):


### PR DESCRIPTION
This happend for example with Queen of the South. The latest season is not on Netflix yet, so the serie and season 5 stays monitored. But because there are no seasons and episodes listed for exclusion and the serie is ended, the table shows that Queen of the south is marked for deletion. However the code does not delete Queen of the South, but the table is showing that is is going to.

This only happens with the `-a delete` action. This should fix the bug because we determine earlier now if the serie should be fully deleted.