### PR TITLE
Add error checking for non numeric TMDB ids

### DIFF
--- a/excludarr/utils/filters.py
+++ b/excludarr/utils/filters.py
@@ -15,30 +15,16 @@ def bool2str(value):
 
 def get_tmdb_ids(external_ids):
     try:
-        all_tmdb_ids = [
-            x["external_id"]
-            for x in external_ids
-            if x["provider"] == "tmdb_latest" or x["provider"] == "tmdb"
-        ]
         tmdb_ids = [
-            int(x)
-            for x in all_tmdb_ids
-            if x.isnumeric()
+            int(x["external_id"])
+            for x in external_ids
+            if (x["provider"] == "tmdb_latest" or x["provider"] == "tmdb") and x["external_id"].isnumeric()
         ]
-        bad_tmdb_ids = [
-            x
-            for x in all_tmdb_ids
-            if not x.isnumeric()
-        ]
-        if (len(bad_tmdb_ids) > 0):
-            print("BAD TMDB IDS:",bad_tmdb_ids)
-
         tmdb_ids = list(set(tmdb_ids))
     except (KeyError, IndexError):
         tmdb_ids = []
 
     return tmdb_ids
-
 
 def get_imdb_ids(external_ids):
     try:

--- a/excludarr/utils/filters.py
+++ b/excludarr/utils/filters.py
@@ -15,11 +15,24 @@ def bool2str(value):
 
 def get_tmdb_ids(external_ids):
     try:
-        tmdb_ids = [
-            int(x["external_id"])
+        all_tmdb_ids = [
+            x["external_id"]
             for x in external_ids
             if x["provider"] == "tmdb_latest" or x["provider"] == "tmdb"
         ]
+        tmdb_ids = [
+            int(x)
+            for x in all_tmdb_ids
+            if x.isnumeric()
+        ]
+        bad_tmdb_ids = [
+            x
+            for x in all_tmdb_ids
+            if not x.isnumeric()
+        ]
+        if (len(bad_tmdb_ids) > 0):
+            print("BAD TMDB IDS:",bad_tmdb_ids)
+
         tmdb_ids = list(set(tmdb_ids))
     except (KeyError, IndexError):
         tmdb_ids = []


### PR DESCRIPTION
Fixes #44 so that program does not abort when ID's returned from TMDB have 'tt' on the start.
Example output:

```
BAD TMDB IDS: ['tt11388406']
BAD TMDB IDS: ['tt11388406']

              ╷                       ╷                ╷                        
 Release Date │ Title                 │ Used Diskspace │ Streaming Providers    
╶─────────────┼───────────────────────┼────────────────┼───────────────────────╴
 2022-01-05   │ Test Movie            │ 0.00GB         │ Netflix  
```
