### PR TITLE
add cron mode in docker and add arm64 container

### DIFF
--- a/.examples/crontab
+++ b/.examples/crontab
@@ -1,0 +1,3 @@
+# minute    hour    day   month   weekday   command
+0           1	      *	    *	      *	        excludarr sonarr -a delete -d -e -y
+0           2	      *	    *	      *	        excludarr radarr -a delete -d -e -y

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,3 +43,6 @@ jobs:
         with:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
+          platforms: |-
+              linux/amd64
+              linux/arm64

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ sonarr_url="${SONARR_URL:-http://localhost:8989}"
 sonarr_api_key="${SONARR_API_KEY:-secret}"
 sonarr_verify_ssl="${SONARR_VERIFY_SSL:-false}"
 sonarr_exclude="[${SONARR_EXCLUDE:-''}]"
+cron_mode="${CRON_MODE:-false}"
 
 
 cat << EOF > /etc/excludarr/excludarr.yml
@@ -41,4 +42,14 @@ tmdb:
 EOF
 fi
 
-excludarr $@
+if [ "$cron_mode" = true ]; then
+    if test -f "/etc/excludarr/crontab"; then
+        cp /etc/excludarr/crontab /var/spool/cron/crontabs/root
+        crond -l 8 -f
+    else
+        echo "No crontab file mounted! Please mount a valid crontab file at /etc/excludarr/crontab before running in cron mode!"
+        exit 1
+    fi
+else
+    excludarr $@
+fi


### PR DESCRIPTION
### Added
- This adds a build process for arm64
- Add cron mode to the docker setup to run the container using cron with a specified crontab file. Useful for docker-compose setups.